### PR TITLE
Switch Slack references to Gardener workspace

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,7 +68,7 @@ The Fix Lead will send a retrospective of the process to the [Gardener mailing l
 
 The [private](#private-disclosure-process) or [public disclosure process](#public-disclosure-process) should be triggered exclusively by writing an e-mail to [secure@sap.com](mailto:secure@sap.com).
 
-Gardener security announcements will be communicated by the Fix Lead sending an e-mail to the [Gardener mailing list](https://groups.google.com/forum/#!forum/gardener) (reachable via [gardener@googlegroups.com](mailto:gardener@googlegroups.com)), as well as posting a link in the [Gardener Slack channel](https://kubernetes.slack.com/messages/CB57N0BFG/details/).
+Gardener security announcements will be communicated by the Fix Lead sending an e-mail to the [Gardener mailing list](https://groups.google.com/forum/#!forum/gardener) (reachable via [gardener@googlegroups.com](mailto:gardener@googlegroups.com)), as well as posting a link in the [#general](https://gardener-cloud.slack.com/archives/CAPMD6DCG) Slack channel (join the workspace [here](https://gardener.cloud/community/community-bio/)).
 
 Public discussions about Gardener security announcements and retrospectives will primarily happen in the Gardener mailing list. Thus Gardener community members who are interested in participating in discussions related to the Gardener Security Release Process are encouraged to join the Gardener mailing list ([how to find and join a group](https://support.google.com/groups/answer/1067205?hl=en)).
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -37,4 +37,4 @@ If you're interested in getting involved, check out our [contribution guidelines
 
 To learn more about Gardener, visit our official website at [https://gardener.cloud](https://gardener.cloud).
 We provide a [free demo playground](https://demo.gardener.cloud/) to provide you with a hands-on experience of Gardener.
-You can also find our documentation [here](https://gardener.cloud/docs/) and can reach out to us via Slack in [Gardener](https://gardener-cloud.slack.com/archives/C045DSWJZB9) and [Kubernetes](https://kubernetes.slack.com/archives/CB57N0BFG) workspaces.
+You can also find our documentation [here](https://gardener.cloud/docs/) and can reach out to us via [Slack](https://gardener-cloud.slack.com/) (join the workspace [here](https://gardener.cloud/community/community-bio/)).


### PR DESCRIPTION
/kind enhancement
/area open-source

**What this PR does / why we need it**:

This PR switches all Slack references to the dedicated Gardener Project workspace.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/documentation/issues/606

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
