### PR TITLE
Update SECURITY.md with Security Officer details

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,11 +23,11 @@ Security vulnerabilities should be handled quickly and sometimes privately. The 
 
 ### Private Disclosure Process
 
-The Gardener community asks that all suspected vulnerabilities be privately and responsibly disclosed. If you've found a vulnerability or a potential vulnerability in Gardener, please let us know by writing an e-mail to [secure@sap.com](mailto:secure@sap.com). We'll send a confirmation e-mail to acknowledge your report, and we'll send an additional e-mail when we've identified the issue positively or negatively.
+The Gardener community asks that all suspected vulnerabilities be privately and responsibly disclosed. If you've found a vulnerability or a potential vulnerability in Gardener, please let us know by writing an e-mail to [gardener-security@lists.neonephos.org](mailto:gardener-security@lists.neonephos.org). We'll send a confirmation e-mail to acknowledge your report, and we'll send an additional e-mail when we've identified the issue positively or negatively.
 
 ### Public Disclosure Process
 
-If you know of a publicly disclosed vulnerability please IMMEDIATELY write an e-mail to [secure@sap.com](mailto:secure@sap.com) to inform the Gardener Security Team about the vulnerability so they may start the patch, release, and communication process.
+If you know of a publicly disclosed vulnerability please IMMEDIATELY write an e-mail to [gardener-security@lists.neonephos.org](mailto:gardener-security@lists.neonephos.org) to inform the Gardener Security Team about the vulnerability so they may start the patch, release, and communication process.
 
 If possible, the Gardener Security Team will ask the person making the public report if the issue can be handled via a [private disclosure process](#private-disclosure-process) (for example, if the full exploit details have not yet been published). If the reporter denies the request for private disclosure, the Gardener Security Team will move swiftly with the fix and release process. In extreme cases GitHub can be asked to delete the issue but this generally isn't necessary and is unlikely to make a public disclosure less damaging.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,10 @@
 
 Gardener is a growing community of volunteers and users. The Gardener community has adopted this security disclosure and response policy to ensure we responsibly handle critical issues.
 
+## Gardener Security Officer
+
+* Eva Kuhnle-Heck (**[@HeckEK](https://github.com/HeckEK)**)
+  
 ## Gardener Security Team
 
 Security vulnerabilities should be handled quickly and sometimes privately. The primary goal of this process is to reduce the total time users are vulnerable to publicly known exploits. The Gardener Security Team is responsible for organizing the entire response, including internal communication and external disclosure, but will need help from relevant developers and release managers to successfully run this process. The Gardener Security Team consists of the following volunteers:


### PR DESCRIPTION
Added information about the Gardener Security Officer.

**What this PR does / why we need it**:
Comply with the requirements to donate Gardener to NeoNephos
CC @ScheererJ

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
