### PR TITLE
Updated the Security team and links

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,14 +10,12 @@ Gardener is a growing community of volunteers and users. The Gardener community 
 
 Security vulnerabilities should be handled quickly and sometimes privately. The primary goal of this process is to reduce the total time users are vulnerable to publicly known exploits. The Gardener Security Team is responsible for organizing the entire response, including internal communication and external disclosure, but will need help from relevant developers and release managers to successfully run this process. The Gardener Security Team consists of the following volunteers:
 
-* Vasu Chandrasekhara, (**[@vasu1124](https://github.com/vasu1124)**)
-* Christian Cwienk, (**[@ccwienk](https://github.com/ccwienk)**)
-* Donka Dimitrova, (**[@donistz](https://github.com/donistz)**)
+* Christian Cwienk (**[@ccwienk](https://github.com/ccwienk)**)
+* Donka Dimitrova (**[@donistz](https://github.com/donistz)**)
 * Eva Kuhnle-Heck (**[@HeckEK](https://github.com/HeckEK)**)
-* Vedran Lerenc, (**[@vlerenc](https://github.com/vlerenc)**)
-* Dirk Marwinski, (**[@marwinski](https://github.com/marwinski)**)
-* Jordan Jordanov, (**[@jordanjordanov](https://github.com/jordanjordanov)**)
-* Philipp Heil, (**[@zkdev](https://github.com/zkdev)**)
+* Vedran Lerenc (**[@vlerenc](https://github.com/vlerenc)**)
+* Dirk Marwinski (**[@marwinski](https://github.com/marwinski)**)
+* Jordan Jordanov (**[@jordanjordanov](https://github.com/jordanjordanov)**)
 
 ## Disclosures
 
@@ -71,10 +69,10 @@ The Fix Lead will send a retrospective of the process to the [Gardener mailing l
 
 ### Communication Channel
 
-The [private](#private-disclosure-process) or [public disclosure process](#public-disclosure-process) should be triggered exclusively by writing an e-mail to [secure@sap.com](mailto:secure@sap.com).
+The [private](#private-disclosure-process) or [public disclosure process](#public-disclosure-process) should be triggered exclusively by writing an e-mail to [gardener-security@lists.neonephos.org](mailto:gardener-security@lists.neonephos.org).
 
 Gardener security announcements will be communicated by the Fix Lead sending an e-mail to the [Gardener mailing list](https://groups.google.com/forum/#!forum/gardener) (reachable via [gardener@googlegroups.com](mailto:gardener@googlegroups.com)), as well as posting a link in the [#general](https://gardener-cloud.slack.com/archives/CAPMD6DCG) Slack channel (join the workspace [here](https://gardener.cloud/community/community-bio/)).
 
 Public discussions about Gardener security announcements and retrospectives will primarily happen in the Gardener mailing list. Thus Gardener community members who are interested in participating in discussions related to the Gardener Security Release Process are encouraged to join the Gardener mailing list ([how to find and join a group](https://support.google.com/groups/answer/1067205?hl=en)).
 
-The members of the [Gardener Security Team](#gardener-security-team) are subscribed to the private [Gardener Security mailing list](https://groups.google.com/forum/#!forum/gardener-security) (reachable via [gardener-security@googlegroups.com](mailto:gardener-security@googlegroups.com)).
+The members of the [Gardener Security Team](#gardener-security-team) are subscribed to the private [Gardener Security mailing list](https://groups.google.com/forum/#!forum/gardener-security) (reachable via [gardener-security@lists.neonephos.org](mailto:gardener-security@lists.neonephos.org)).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,7 +73,7 @@ The Fix Lead will send a retrospective of the process to the [Gardener mailing l
 
 The [private](#private-disclosure-process) or [public disclosure process](#public-disclosure-process) should be triggered exclusively by writing an e-mail to [gardener-security@lists.neonephos.org](mailto:gardener-security@lists.neonephos.org).
 
-Gardener security announcements will be communicated by the Fix Lead sending an e-mail to the [Gardener mailing list](https://groups.google.com/forum/#!forum/gardener) (reachable via [gardener@googlegroups.com](mailto:gardener@googlegroups.com)), as well as posting a link in the [#general](https://gardener-cloud.slack.com/archives/CAPMD6DCG) Slack channel (join the workspace [here](https://gardener.cloud/community/community-bio/)).
+Gardener security announcements will be communicated by the Fix Lead sending an e-mail to the [Gardener mailing list](https://groups.google.com/forum/#!forum/gardener) (reachable via [gardener@googlegroups.com](mailto:gardener@googlegroups.com)), as well as posting a link in the [#general](https://gardener-cloud.slack.com/archives/CAPMD6DCG) Slack channel (join the workspace [here](https://gardener.cloud/community/#get-connected)).
 
 Public discussions about Gardener security announcements and retrospectives will primarily happen in the Gardener mailing list. Thus Gardener community members who are interested in participating in discussions related to the Gardener Security Release Process are encouraged to join the Gardener mailing list ([how to find and join a group](https://support.google.com/groups/answer/1067205?hl=en)).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,10 +71,10 @@ The Fix Lead will send a retrospective of the process to the [Gardener mailing l
 
 ### Communication Channel
 
-The [private](#private-disclosure-process) or [public disclosure process](#public-disclosure-process) should be triggered exclusively by writing an e-mail to [secure@sap.com](mailto:secure@sap.com).
+The [private](#private-disclosure-process) or [public disclosure process](#public-disclosure-process) should be triggered exclusively by writing an e-mail to [gardener-security@lists.neonephos.org](mailto:gardener-security@lists.neonephos.org).
 
 Gardener security announcements will be communicated by the Fix Lead sending an e-mail to the [Gardener mailing list](https://groups.google.com/forum/#!forum/gardener) (reachable via [gardener@googlegroups.com](mailto:gardener@googlegroups.com)), as well as posting a link in the [#general](https://gardener-cloud.slack.com/archives/CAPMD6DCG) Slack channel (join the workspace [here](https://gardener.cloud/community/community-bio/)).
 
 Public discussions about Gardener security announcements and retrospectives will primarily happen in the Gardener mailing list. Thus Gardener community members who are interested in participating in discussions related to the Gardener Security Release Process are encouraged to join the Gardener mailing list ([how to find and join a group](https://support.google.com/groups/answer/1067205?hl=en)).
 
-The members of the [Gardener Security Team](#gardener-security-team) are subscribed to the private [Gardener Security mailing list](https://groups.google.com/forum/#!forum/gardener-security) (reachable via [gardener-security@googlegroups.com](mailto:gardener-security@googlegroups.com)).
+The members of the [Gardener Security Team](#gardener-security-team) are subscribed to the private [Gardener Security mailing list](https://groups.google.com/forum/#!forum/gardener-security) (reachable via [gardener-security@lists.neonephos.org](mailto:gardener-security@lists.neonephos.org)).


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR updates the `SECURITY.md` page:
- Updates the security team personnel
- Updates links to point to neonephos
- Fixes broken link

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/documentation/issues/923

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```